### PR TITLE
Fix a warning produced when second parameter for in_array check was actu...

### DIFF
--- a/cheezcap.php
+++ b/cheezcap.php
@@ -305,7 +305,7 @@ class CheezCap {
 function cheezcap_get_option( $option, $echo = false, $sanitize_callback = '' ) {
 	global $cap;
 
-	$value = isset( $cap->$option ) ? $cap->$option : null;
+	$value = $cap->$option;
 	
 	if( $sanitize_callback && is_callable( $sanitize_callback ) )
 		$value = call_user_func( $sanitize_callback, $value );


### PR DESCRIPTION
...ally a string instead of array. This check is needed to determine if a checkbox in a set of values for multiple checkboxes is selected but only one or no values were set, resulting options_checked variable being a string instead of an array. Cast to array before doing the check
