### PR TITLE
PHP 8.2: Fix for deprecated setting of dynamic property

### DIFF
--- a/library.php
+++ b/library.php
@@ -154,6 +154,7 @@ class CheezCapTextOption extends CheezCapOption {
 
 class CheezCapDropdownOption extends CheezCapOption {
 	var $options;
+	var $options_labels;
 
 	function __construct( $_name, $_desc, $_id, $_options, $_stdIndex = 0, $_options_labels = array(), $_validation_cb = false ) {
 		$_std = ! isset( $_options[$_stdIndex] ) ? $_options[0] : $_options[$_stdIndex];


### PR DESCRIPTION
In PHP 8.2, dynamically setting object properties that haven't been defined has been deprecated. `CheezCapDropdownOption` does this with `$options_labels`, leading to a number of these notices.

The solution is simple - we simply need to define the properties in the class, which this PR does.